### PR TITLE
improve bulk-user-load CSV processing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
-bandit~=1.7.5
-black~=23.11.0
-flake8~=6.1.0
-isort~=5.12.0
-mypy~=1.7.1
+bandit~=1.7.6
+black~=23.12.1
+flake8~=7.0.0
+isort~=5.13.2
+mypy~=1.8.0
 pycodestyle~=2.11.1
-pylint~=3.0.2
-pytest~=7.4.3
-types-requests~=2.31.0.10
+pylint~=3.0.3
+pytest~=7.4.4
+types-requests~=2.31.0.20240106

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-basecfg~=2.1.0
+basecfg~=2.1.1
 baselog~=2.0.1
-bcrypt~=4.1.1
+bcrypt~=4.1.2
 ctds~=1.14.0
 psycopg2-binary~=2.9.9
 requests~=2.31.0

--- a/src/glue/webapi_db.py
+++ b/src/glue/webapi_db.py
@@ -72,11 +72,14 @@ def bulk_ensure_basic_security_users(
     with open(
         config.bulk_user_file, "rt", newline="", encoding="utf-8", errors="strict"
     ) as csvfh:
-        csvfile = csv.DictReader(
-            csvfh,
-            BasicSecurityUserBulkEntry._fields,
-            dialect=csv.unix_dialect,
-        )
+        csvfile = csv.DictReader(csvfh, dialect=csv.unix_dialect)
+        # verify fields and header row match
+        if csvfile.fieldnames != BasicSecurityUserBulkEntry._fields:
+            logger.error(
+                "header row in csv doesn't match expected headers; have:%s, want:%s",
+                repr(csvfile.fieldnames),
+                repr(BasicSecurityUserBulkEntry._fields),
+            )
         for row in csvfile:
             csv_record = BasicSecurityUserBulkEntry(**row)
             csv_users[csv_record.username] = csv_record

--- a/src/glue/webapi_db.py
+++ b/src/glue/webapi_db.py
@@ -17,6 +17,7 @@ from .models import (
     SecRole,
 )
 from .util.security import bcrypt_check, bcrypt_hash
+from .webapi import WebAPIClient
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,11 @@ def bulk_ensure_basic_security_users(
             lastname=csv_record.lastname,
             password_hash=bcrypt_hash(csv_record.password),
         )
+        # sign-in with no-privs to init the sec_* tables entries
+        user_config = config
+        user_config.atlas_username = csv_record.username
+        user_config.atlas_password = csv_record.password
+        _ = WebAPIClient(user_config)
         result[user] = "CREATED"
 
     return result

--- a/src/glue/webapi_db.py
+++ b/src/glue/webapi_db.py
@@ -75,11 +75,11 @@ def bulk_ensure_basic_security_users(
     ) as csvfh:
         csvfile = csv.DictReader(csvfh, dialect=csv.unix_dialect)
         # verify fields and header row match
-        if csvfile.fieldnames != BasicSecurityUserBulkEntry._fields:
+        if csvfile.fieldnames != list(BasicSecurityUserBulkEntry._fields):
             logger.error(
                 "header row in csv doesn't match expected headers; have:%s, want:%s",
                 repr(csvfile.fieldnames),
-                repr(BasicSecurityUserBulkEntry._fields),
+                repr(list(BasicSecurityUserBulkEntry._fields)),
             )
         for row in csvfile:
             csv_record = BasicSecurityUserBulkEntry(**row)

--- a/src/glue/webapi_db.py
+++ b/src/glue/webapi_db.py
@@ -99,6 +99,8 @@ def bulk_ensure_basic_security_users(
     updates = db_users.keys() & csv_users.keys()  # update - user in both
 
     for user in deletes:
+        # NOTE! WHEN IMPLEMENTING: GATE DELETES BEHIND AN OPT-IN CONFIG VALUE!
+        # existing users are depending on the non-delete batch behavior
         logger.warning("DELETE USER %s - delete is not currently implemented", user)
         result[user] = "ERROR"
         # result[user] = BULK_USER_STATUS_DELETED


### PR DESCRIPTION
Check the bulk-user-load CSV dictreader's headers instead of feeding the headers to the CSV dict reader; this prevents the header-as-data problem and we may get a more explicit error message. We also have the option of doing a set-wise comparison if we want to allow headers to be in any order.

Additionally we prompt webapi to init the sec_* table entries for each new account by logging in with the new credentials.
