### PR TITLE
cem and concept count tables are in the cdm_db not in the app db

### DIFF
--- a/src/glue/webapi.py
+++ b/src/glue/webapi.py
@@ -122,7 +122,7 @@ class WebAPIClient:
         search
         """
         params = {
-            "dialect": self.config.db_dialect,
+            "dialect": self.config.cdm_db_dialect,
             "schema": self.config.results_schema,
             "vocabSchema": self.config.vocab_schema,
         }
@@ -136,7 +136,7 @@ class WebAPIClient:
         the CDMDB
         """
         params = {
-            "dialect": self.config.db_dialect,
+            "dialect": self.config.cdm_db_dialect,
             "schema": self.config.cem_results_schema,
             "vocabSchema": self.config.vocab_schema,
         }


### PR DESCRIPTION
There is an issue creating concept_count tables in the cdm db, when mixing appdb as postgresql and cdmdb as sql server. I believe this patch fixes the issue