### PR TITLE
fix dialect param in get_results_ddl

### DIFF
--- a/src/glue/webapi.py
+++ b/src/glue/webapi.py
@@ -99,13 +99,13 @@ class WebAPIClient:
         get SQL code which can be used to establish the results schema
         """
         params = {
-            "dialect": self.config.db_dialect,
+            "dialect": self.config.cdm_db_dialect,
             "schema": self.config.results_schema,
             "vocabSchema": self.config.vocab_schema,
             "tempSchema": self.config.temp_schema,
-            "initConceptHierarchy": "true"
-            if self.config.init_concept_hierarchy
-            else "false",
+            "initConceptHierarchy": (
+                "true" if self.config.init_concept_hierarchy else "false"
+            ),
         }
         result = self.get("/ddl/results", params=params)
         result.raise_for_status()


### PR DESCRIPTION
Extends fix from #43 to include `get_results_ddl`.